### PR TITLE
Feature/support sunspot grouping

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Or install it yourself as:
 
 ## Usage
 
-RSpec case:
+RSpec examples:
 
 ```ruby
 RSpec.describe 'stubbed Solr result' do
@@ -42,6 +42,25 @@ RSpec.describe 'stubbed Solr result' do
   end
 end
 ```
+Example using grouped search:
+
+```ruby
+RSpec.describe 'stubbed grouped Solr result' do
+  let(:grouped_search) { Sunspot::NullResult.new(records, group_by: :category_id) }
+  before { allow(MyModel).to receive_message_chain('search.group').and_return(grouped_search) }
+
+  context 'with no records' do
+    let(:records) { [] }
+    # …
+  end
+
+  context 'with some records' do
+    let(:records) { [MyModel.new, MyModel.new] }
+    # …
+  end
+end
+```
+
 
 Rescue case for unavailable Solr server, e.g. Websolr having issues.
 

--- a/README.md
+++ b/README.md
@@ -83,6 +83,9 @@ end
 
 ### HEAD (not yet released)
 
+### v0.3.0
+* Support Sunspot grouping
+
 ### v0.2.0
 * Allow setting of pagination options and calculate dependent values accordingly
 

--- a/README.md
+++ b/README.md
@@ -34,33 +34,24 @@ RSpec.describe 'stubbed Solr result' do
   context 'with no records' do
     let(:records) { [] }
     # …
+
+    it 'supports grouping' do
+      # …
+      expect(search.group(:my_attribute)).to eql []
+    end
   end
 
   context 'with some records' do
     let(:records) { [MyModel.new, MyModel.new] }
     # …
+
+    it 'supports grouping' do
+      # …
+      expect(search.group(:my_attribute)).not_to be_empty
+    end
   end
 end
 ```
-Example using grouped search:
-
-```ruby
-RSpec.describe 'stubbed grouped Solr result' do
-  let(:grouped_search) { Sunspot::NullResult.new(records, group_by: :category_id) }
-  before { allow(MyModel).to receive_message_chain('search.group').and_return(grouped_search) }
-
-  context 'with no records' do
-    let(:records) { [] }
-    # …
-  end
-
-  context 'with some records' do
-    let(:records) { [MyModel.new, MyModel.new] }
-    # …
-  end
-end
-```
-
 
 Rescue case for unavailable Solr server, e.g. Websolr having issues.
 

--- a/lib/sunspot/null_result.rb
+++ b/lib/sunspot/null_result.rb
@@ -1,5 +1,7 @@
 require "sunspot/null_result/version"
 require "sunspot/null_result/grouped_collection"
+require "sunspot/null_result/group"
+require "sunspot/null_result/hit"
 
 module Sunspot
   class NullResult
@@ -65,7 +67,7 @@ module Sunspot
     end
 
     def groups
-      []
+      GroupedCollection.new(collection, options[:group_by]).to_a
     end
 
   end

--- a/lib/sunspot/null_result.rb
+++ b/lib/sunspot/null_result.rb
@@ -2,10 +2,11 @@ require "sunspot/null_result/version"
 
 module Sunspot
   class NullResult
-    attr_reader :collection, :options
+    attr_reader :collection, :options, :group_by
 
-    def initialize(*collection, **options)
+    def initialize(*collection, group_by: nil, **options)
       @collection = collection.flatten
+      @group_by   = group_by
       @options    = options
     end
 
@@ -60,6 +61,10 @@ module Sunspot
 
     def results
       PaginatedNullArray.new(collection, options)
+    end
+
+    def groups
+      []
     end
 
   end

--- a/lib/sunspot/null_result.rb
+++ b/lib/sunspot/null_result.rb
@@ -67,7 +67,7 @@ module Sunspot
     end
 
     def groups
-      GroupedCollection.new(collection, options[:group_by]).to_a
+      GroupedCollection.new(collection, group_by).to_a
     end
 
   end

--- a/lib/sunspot/null_result.rb
+++ b/lib/sunspot/null_result.rb
@@ -1,4 +1,5 @@
 require "sunspot/null_result/version"
+require "sunspot/null_result/grouped_collection"
 
 module Sunspot
   class NullResult

--- a/lib/sunspot/null_result.rb
+++ b/lib/sunspot/null_result.rb
@@ -7,10 +7,10 @@ module Sunspot
   class NullResult
     attr_reader :collection, :options, :group_by
 
-    def initialize(*collection, group_by: nil, **options)
+    def initialize(*collection, **options)
       @collection = collection.flatten
-      @group_by   = group_by
       @options    = options
+      @group_by   = nil
     end
 
     # Implements the interface of
@@ -64,6 +64,11 @@ module Sunspot
 
     def results
       PaginatedNullArray.new(collection, options)
+    end
+
+    def group(group)
+      @group_by = group
+      self
     end
 
     def groups

--- a/lib/sunspot/null_result/group.rb
+++ b/lib/sunspot/null_result/group.rb
@@ -1,0 +1,15 @@
+module Sunspot
+  class NullResult
+    class Group < Struct.new(:value, :primary_keys, :collection_item_class_name)
+
+      def solr_docs
+        primary_keys.map { |id| "#{collection_item_class_name.to_s} #{id}" }
+      end
+
+      def hits
+        primary_keys.map { |id| Hit.new(id) }
+      end
+
+    end
+  end
+end

--- a/lib/sunspot/null_result/group.rb
+++ b/lib/sunspot/null_result/group.rb
@@ -1,13 +1,13 @@
 module Sunspot
   class NullResult
-    class Group < Struct.new(:value, :primary_keys, :collection_item_class_name)
+    class Group < Struct.new(:value, :collection)
 
       def solr_docs
-        primary_keys.map { |id| "#{collection_item_class_name.to_s} #{id}" }
+        collection.map { |item| "#{item.class.to_s} #{item.id}" }
       end
 
       def hits
-        primary_keys.map { |id| Hit.new(id) }
+        collection.map { |item| Hit.new item.id }
       end
 
     end

--- a/lib/sunspot/null_result/grouped_collection.rb
+++ b/lib/sunspot/null_result/grouped_collection.rb
@@ -12,7 +12,11 @@ module Sunspot
       end
 
       def to_a
-        collection.group_by(&group_by).values
+        grouped = collection.group_by(&group_by)
+
+        grouped.keys.map do |group_key|
+          Group.new(group_key, grouped[group_key], collection.first.class.to_s)
+        end
       end
 
       def each(*args, &block)

--- a/lib/sunspot/null_result/grouped_collection.rb
+++ b/lib/sunspot/null_result/grouped_collection.rb
@@ -15,7 +15,7 @@ module Sunspot
         grouped = collection.group_by(&group_by)
 
         grouped.keys.map do |group_key|
-          Group.new(group_key, grouped[group_key], collection.first.class.to_s)
+          Group.new(group_key, grouped[group_key])
         end
       end
 

--- a/lib/sunspot/null_result/grouped_collection.rb
+++ b/lib/sunspot/null_result/grouped_collection.rb
@@ -1,18 +1,23 @@
 module Sunspot
   class NullResult
-    class GroupedCollection < SimpleDelegator
+    class GroupedCollection
+
+      include Enumerable
+
       attr_reader :collection, :group_by
 
       def initialize(collection, group_by = nil)
-        @collection = group_by.nil? ? [] : collection
-        super(@collection)
-        @group_by = group_by
+        @collection = group_by.nil? ? [] : Array(collection)
+        @group_by = group_by || :itself
       end
 
       def to_a
         collection.group_by(&group_by).values
       end
 
+      def each(*args, &block)
+        to_a.each(*args, &block)
+      end
 
     end
   end

--- a/lib/sunspot/null_result/grouped_collection.rb
+++ b/lib/sunspot/null_result/grouped_collection.rb
@@ -1,0 +1,19 @@
+module Sunspot
+  class NullResult
+    class GroupedCollection < SimpleDelegator
+      attr_reader :collection, :group_by
+
+      def initialize(collection, group_by = nil)
+        @collection = group_by.nil? ? [] : collection
+        super(@collection)
+        @group_by = group_by
+      end
+
+      def to_a
+        collection.group_by(&group_by).values
+      end
+
+
+    end
+  end
+end

--- a/lib/sunspot/null_result/hit.rb
+++ b/lib/sunspot/null_result/hit.rb
@@ -1,0 +1,6 @@
+module Sunspot
+  class NullResult
+    class Hit < Struct.new(:primary_key)
+    end
+  end
+end

--- a/lib/sunspot/null_result/version.rb
+++ b/lib/sunspot/null_result/version.rb
@@ -1,5 +1,5 @@
 module Sunspot
   class NullResult
-    VERSION = "0.2.0"
+    VERSION = "0.3.0"
   end
 end

--- a/spec/sunspot/group_spec.rb
+++ b/spec/sunspot/group_spec.rb
@@ -2,14 +2,13 @@ require 'spec_helper'
 
 RSpec.describe Sunspot::NullResult::Group do
 
-  let(:collection_item_class_name) { 'Monkey'   }
-  let(:collection_primary_keys)    { ['a', 'b'] }
+  let(:collection) { [1, 2].map { |id| klass.new('foo', id) } }
 
-  subject { described_class.new(42, collection_primary_keys, collection_item_class_name) }
+  subject { described_class.new(42, collection) }
 
   describe '#solr_docs' do
     it 'build solr document list as expected' do
-      expect(subject.solr_docs).to eql ['Monkey a', 'Monkey b']
+      expect(subject.solr_docs).to eql ['Struct::Monkey 1', 'Struct::Monkey 2']
     end
   end
 
@@ -34,4 +33,9 @@ RSpec.describe Sunspot::NullResult::Group do
       end
     end
   end
+
+  def klass
+    @klass ||= Struct.new('Monkey', :foobar, :id)
+  end
+
 end

--- a/spec/sunspot/group_spec.rb
+++ b/spec/sunspot/group_spec.rb
@@ -1,0 +1,37 @@
+require 'spec_helper'
+
+RSpec.describe Sunspot::NullResult::Group do
+
+  let(:collection_item_class_name) { 'Monkey'   }
+  let(:collection_primary_keys)    { ['a', 'b'] }
+
+  subject { described_class.new(42, collection_primary_keys, collection_item_class_name) }
+
+  describe '#solr_docs' do
+    it 'build solr document list as expected' do
+      expect(subject.solr_docs).to eql ['Monkey a', 'Monkey b']
+    end
+  end
+
+  describe '#hits' do
+    RSpec::Matchers.define :be_sunspot_hit_compliant do
+      match do |actual|
+        @missing_methods = []
+        [:primary_key].each do |meth|
+          @missing_methods << meth unless actual.respond_to? meth
+        end
+        @missing_methods.empty?
+      end
+
+      failure_message do |actual|
+        "#{actual} does not respond to these methods: #{@missing_methods.inspect}"
+      end
+    end
+
+    it 'implements sunspot hit interface' do
+      subject.hits.each do |item|
+        expect(item).to be_sunspot_hit_compliant
+      end
+    end
+  end
+end

--- a/spec/sunspot/grouped_collection_spec.rb
+++ b/spec/sunspot/grouped_collection_spec.rb
@@ -25,7 +25,15 @@ RSpec.describe Sunspot::NullResult::GroupedCollection do
 
       RSpec::Matchers.define :be_sunspot_group_result_compliant do
         match do |actual|
-          [:solr_docs, :hits].all? { |meth| actual.respond_to? meth }
+          @missing_methods = []
+          [:solr_docs, :hits].each do |meth|
+            @missing_methods << meth unless actual.respond_to? meth
+          end
+          @missing_methods.empty?
+        end
+
+        failure_message do |actual|
+          "#{actual} does not respond to these methods: #{@missing_methods.inspect}"
         end
       end
 

--- a/spec/sunspot/grouped_collection_spec.rb
+++ b/spec/sunspot/grouped_collection_spec.rb
@@ -16,11 +16,23 @@ RSpec.describe Sunspot::NullResult::GroupedCollection do
   describe '#to_a' do
     context 'with group_by specified' do
       let(:attribute) { :foobar }
-      subject { described_class.new(collection, attribute) }
+      subject { described_class.new(collection, attribute).to_a }
 
       it 'groups its collection by given attribute' do
-        expect(subject.to_a).to be_kind_of Array
-        expect(subject.to_a).to match_array collection.group_by(&attribute).values
+        expect(subject).to be_kind_of Array
+        expect(subject).to match_array collection.group_by(&attribute).values
+      end
+
+      RSpec::Matchers.define :be_sunspot_group_result_compliant do
+        match do |actual|
+          [:solr_docs, :hits].all? { |meth| actual.respond_to? meth }
+        end
+      end
+
+      it 'implements grouped sunspot result interface' do
+        subject.each do |item|
+          expect(item).to be_sunspot_group_result_compliant
+        end
       end
     end
   end

--- a/spec/sunspot/grouped_collection_spec.rb
+++ b/spec/sunspot/grouped_collection_spec.rb
@@ -1,0 +1,32 @@
+require 'spec_helper'
+
+RSpec.describe Sunspot::NullResult::GroupedCollection do
+
+  let(:values) { %w(one two three) }
+  let(:collection) { (values*2).map { |value| klass.new(value) }.shuffle }
+
+  describe 'its constructor' do
+    context 'without group_by specified' do
+      it 'returns empty list' do
+        expect(described_class.new(collection)).to eql([])
+      end
+    end
+  end
+
+  describe '#to_a' do
+    context 'with group_by specified' do
+      let(:attribute) { :foobar }
+      subject { described_class.new(collection, attribute) }
+
+      it 'groups its collection by given attribute' do
+        expect(subject.to_a).to be_kind_of Array
+        expect(subject.to_a).to match_array collection.group_by(&attribute).values
+      end
+    end
+  end
+
+  def klass
+    @klass ||= Struct.new(:foobar)
+  end
+
+end

--- a/spec/sunspot/grouped_collection_spec.rb
+++ b/spec/sunspot/grouped_collection_spec.rb
@@ -5,18 +5,24 @@ RSpec.describe Sunspot::NullResult::GroupedCollection do
   let(:values) { %w(one two three) }
   let(:collection) { (values*2).map { |value| klass.new(value) }.shuffle }
 
-  describe 'its constructor' do
-    context 'without group_by specified' do
-      it 'returns empty list' do
-        expect(described_class.new(collection)).to eql([])
-      end
-    end
+  describe 'its delegation behavior' do
+    subject { described_class.new(collection) }
+    it { is_expected.to respond_to(:each); subject.each { |i| } }
   end
 
   describe '#to_a' do
+    subject { described_class.new(collection, attribute).to_a }
+
+    context 'without group_by specified' do
+      let(:attribute) {}
+
+      it 'returns empty list' do
+        expect(subject).to be_empty
+      end
+    end
+
     context 'with group_by specified' do
       let(:attribute) { :foobar }
-      subject { described_class.new(collection, attribute).to_a }
 
       it 'groups its collection by given attribute' do
         expect(subject).to be_kind_of Array

--- a/spec/sunspot/grouped_collection_spec.rb
+++ b/spec/sunspot/grouped_collection_spec.rb
@@ -24,10 +24,7 @@ RSpec.describe Sunspot::NullResult::GroupedCollection do
     context 'with group_by specified' do
       let(:attribute) { :foobar }
 
-      it 'groups its collection by given attribute' do
-        expect(subject).to be_kind_of Array
-        expect(subject).to match_array collection.group_by(&attribute).values
-      end
+      it { expect(subject).to be_kind_of Array }
 
       RSpec::Matchers.define :be_sunspot_group_result_compliant do
         match do |actual|

--- a/spec/sunspot/grouped_collection_spec.rb
+++ b/spec/sunspot/grouped_collection_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe Sunspot::NullResult::GroupedCollection do
       RSpec::Matchers.define :be_sunspot_group_result_compliant do
         match do |actual|
           @missing_methods = []
-          [:solr_docs, :hits].each do |meth|
+          [:solr_docs, :hits, :value].each do |meth|
             @missing_methods << meth unless actual.respond_to? meth
           end
           @missing_methods.empty?

--- a/spec/sunspot/hit_spec.rb
+++ b/spec/sunspot/hit_spec.rb
@@ -1,0 +1,5 @@
+require 'spec_helper'
+
+RSpec.describe Sunspot::NullResult::Hit do
+  it { expect(subject).to respond_to(:primary_key) }
+end

--- a/spec/sunspot/null_result_spec.rb
+++ b/spec/sunspot/null_result_spec.rb
@@ -138,5 +138,13 @@ RSpec.describe Sunspot::NullResult do
     it 'returns an empty list' do
       expect(subject.groups).to eql([])
     end
+
+    context 'with an :group_by option' do
+      subject { described_class.new(collection, group_by: :itself) }
+
+      it 'still is an array' do
+        expect(subject.groups).to be_kind_of Array
+      end
+    end
   end
 end

--- a/spec/sunspot/null_result_spec.rb
+++ b/spec/sunspot/null_result_spec.rb
@@ -21,11 +21,6 @@ RSpec.describe Sunspot::NullResult do
       it 'leaves group_by blank' do
         expect(subject.group_by).to be_nil
       end
-
-      it 'sets the group_by' do
-        subject = described_class.new collection, group_by: :foobar
-        expect(subject.group_by).to eql :foobar
-      end
     end
   end
 
@@ -132,6 +127,27 @@ RSpec.describe Sunspot::NullResult do
     it_behaves_like 'returns a paginated enumerable', :results
     it_behaves_like 'returns injected results list',  :results
     it_behaves_like 'allows injection of pagination options', :results
+  end
+
+  describe '#group' do
+    let(:collection) do
+      %w(one two).map { |group| Struct.new(:foobar, :id).new(group, '_') }
+    end
+
+    subject { described_class.new(collection) }
+
+    it 'sets the group_by' do
+      expect { subject.group(:foobar) }.
+        to change { subject.group_by }.to :foobar
+    end
+
+    it 'returns itself' do
+      expect(subject.group(:foobar)).to eql subject
+    end
+
+    it 'returns a grouped result' do
+      expect(subject.group(:foobar).groups).not_to be_empty
+    end
   end
 
   describe '#groups' do

--- a/spec/sunspot/null_result_spec.rb
+++ b/spec/sunspot/null_result_spec.rb
@@ -16,6 +16,17 @@ RSpec.describe Sunspot::NullResult do
       subject = described_class.new collection
       expect(subject.collection).to eql collection
     end
+
+    context 'with grouping' do
+      it 'leaves group_by blank' do
+        expect(subject.group_by).to be_nil
+      end
+
+      it 'sets the group_by' do
+        subject = described_class.new collection, group_by: :foobar
+        expect(subject.group_by).to eql :foobar
+      end
+    end
   end
 
   shared_examples_for 'returns a paginated enumerable' do |method|
@@ -123,4 +134,9 @@ RSpec.describe Sunspot::NullResult do
     it_behaves_like 'allows injection of pagination options', :results
   end
 
+  describe '#groups' do
+    it 'returns an empty list' do
+      expect(subject.groups).to eql([])
+    end
+  end
 end

--- a/sunspot-null_result.gemspec
+++ b/sunspot-null_result.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = ">= 2.1.0"
+  spec.required_ruby_version = ">= 2.2.0"
 
   spec.add_development_dependency "bundler", "~> 1.10"
   spec.add_development_dependency "rake", "~> 10.0"


### PR DESCRIPTION
Supports grouping mechanics for Sunspot search 
- Mimicks interface we rely on using seperate stub objects `Group`, `Hit`, `GroupedCollection`
- Uses Ruby 2.2 specific features (e.g. `Object#itself`) and therefore changes Ruby version compability
- Bumps version to v0.3.0

@carpodaster, I think it would be good if you could have a final look at these changes. Thanks! 
